### PR TITLE
Fix toggling in visual block mode, replacing current WORD instead of toggled word, and make sure toggled word remains toggleable

### DIFF
--- a/autoload/CtrlXA.vim
+++ b/autoload/CtrlXA.vim
@@ -38,8 +38,9 @@ function! CtrlXA#MultipleInc(key) abort
   let cnt = v:count1
   exe "normal " . cnt . a:key
   if line("'<") < line("'>")
+    let is_blockmode = (visualmode() ==# "\<C-v>")
     " increment all subsequent lines
-    exe "'<+1,'>normal " . cnt . a:key
+    exe "'<+1,'>normal " . (is_blockmode ? col("'<") . "|" : '') . cnt . a:key
   endif
 
   silent! call repeat#set(a:key , cnt)

--- a/autoload/CtrlXA.vim
+++ b/autoload/CtrlXA.vim
@@ -23,7 +23,7 @@ function! CtrlXA#SingleInc(key) abort
       if cword is# current_toggle
         let next_toggle = toggles[(i + increment) % len]
 
-        return "m`:\<c-u>call search('[[:xdigit:][:keyword:]]','cz', line('.'))\<cr>" . "\"_ciw" . next_toggle . "\<esc>g``" . repeat
+        return "m`viwo\<esc>:\<c-u>call search('" . cword . "','cz', line('.'))\<cr>" . "\"_ciw" . next_toggle . "\<esc>g``" . repeat
       endif
 
       let i = i+1

--- a/autoload/CtrlXA.vim
+++ b/autoload/CtrlXA.vim
@@ -1,6 +1,9 @@
 function! CtrlXA#SingleInc(key) abort
   " use vim-repeat to ensure @. = <C-A/X>
   let repeat = ":silent! call repeat#set('" . a:key . "','" . v:count . "')\<cr>"
+  " only jump the cursor back if it would leave it before the end of the new
+  " word to allow repeat toggles.
+  let jump_back = ":if col('.')>col(\"'`\")|exe 'normal g``'|endif\<cr>"
 
   let increment = v:count1 * (a:key is? "\<C-A>" ? 1 : -1)
 
@@ -17,13 +20,13 @@ function! CtrlXA#SingleInc(key) abort
       if cWORD is# current_toggle
         let next_toggle = toggles[(i + increment) % len]
 
-        return "m`:\<c-u>call search('\\S','cz', line('.'))\<cr>" .  "\"_ciW" . next_toggle . "\<esc>g``" . repeat
+        return "m`:\<c-u>call search('\\S','cz', line('.'))\<cr>" .  "\"_ciW" . next_toggle . "\<esc>" . jump_back . repeat
       endif
 
       if cword is# current_toggle
         let next_toggle = toggles[(i + increment) % len]
 
-        return "m`viwo\<esc>:\<c-u>call search('" . cword . "','cz', line('.'))\<cr>" . "\"_ciw" . next_toggle . "\<esc>g``" . repeat
+        return "m`viwo\<esc>:\<c-u>call search('" . cword . "','cz', line('.'))\<cr>" . "\"_ciw" . next_toggle . "\<esc>" . jump_back . repeat
       endif
 
       let i = i+1


### PR DESCRIPTION
I found a couple of things that can be improved. Examples are in the commit messages.

What was the reason for using `[[:xdigit:][:keyword:]]`? I may be missing something there.

Let me know what can be improved. I'm sure that `jump_back` can be.