### PR TITLE
Define `g:CtrlXA_iskeyword` as a default and for global custom keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ If you want to add a cycle, say the pair `['sweet', 'bitter']`, to the default l
     augroup END
     ```
 
+Keywords are separated by all non-keyword characters. Keyword characters are determined by the global variable `g:CtrlXA_iskeyword`. By default, this variable takes the same value as `:h iskeyword`, so default keywords in CtrlXA are the same as Vim keywords. To customize, add or remove characters from `g:CtrlXA_iskeyword`. For example, remove the underscore `_` to toggle `max` and `x` in `max_x`.
+
 ## Buffer-Local Configuration Options
 
 There is also its buffer-local analogue, which allows for file-type specific
@@ -128,10 +130,7 @@ When there are already default cycles for a file type, say for `TeX`, replace th
 
 to the file `~/.vim/after/ftplugin/tex.vim` on Linux (respectively `%USERPROFILE%\vimfiles\after\ftplugin\tex.vim` on Microsoft Windows).
 
-The buffer-local variable `b:CtrlXA_iskeyword` can be used instead of
-`&iskeyword` to detect keywords; useful if a toggle keyword is nested inside
-another keyword (as defined by `&iskeyword`). For example, the keywords `max`
-and `x` in `max_x`.
+The buffer-local variable `b:CtrlXA_iskeyword` can be used instead of the global `g:CtrlXA_iskeyword` to separate keywords. Useful to define keywords based on filetype. For example, set `b:CtrlXA_iskeyword` in `~/.vim/ftplugin/python.vim` to define keywords in Python.
 
 # Related Plug-ins
 

--- a/autoload/CtrlXA.vim
+++ b/autoload/CtrlXA.vim
@@ -11,8 +11,9 @@ function! CtrlXA#SingleInc(key) abort
         \ v:count . "\")\<cr>"
 
   if exists('b:CtrlXA_iskeyword')
-    let l:iskeyword = &l:iskeyword
-    let &l:iskeyword = b:CtrlXA_iskeyword  
+    let &l:iskeyword = b:CtrlXA_iskeyword
+  else
+    let &l:iskeyword = g:CtrlXA_iskeyword
   endif
 
   let cword = expand('<cword>')

--- a/plugin/CtrlXA.vim
+++ b/plugin/CtrlXA.vim
@@ -24,6 +24,10 @@ let s:keepcpo         = &cpo
 set cpo&vim
 " ------------------------------------------------------------------------------
 
+if !exists('g:CtrlXA_iskeyword')
+    let g:CtrlXA_iskeyword = &l:iskeyword
+endif
+
 if !exists('g:CtrlXA_Toggles')
   let g:CtrlXA_Toggles = [
       \ ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'w', 'x', 'y', 'z'],


### PR DESCRIPTION
- `g:CtrlXA_iskeyword` can be set by the user in their `.vimrc`. If not set
by the user, it will collect the characters from `l:iskeyword`, the local
version of `iskeyword` (in case `setlocal iskeyword` was used to set
buffer-specific keywords).
- `b:CtrlXA_iskeyword` can be set by the user in `ftplugin/filetype.vim`
to define filetype-specific keywords. If not set by the user,
`g:CtrlXA_iskeyword` will be used instead.