### PR TITLE
reset &iskeyword in time also for numeric toggles

### DIFF
--- a/autoload/CtrlXA.vim
+++ b/autoload/CtrlXA.vim
@@ -31,7 +31,7 @@ function! CtrlXA#SingleInc(key) abort
         \ || cursor_char =~# '\d' || (cursor_char ==# '-') && (cursor_char_next =~# '\d')
         \ || (&nrformats =~# '\<bin\>') && (cursor_char =~# '[bB]' && cursor_char_next =~# '[01]' && cursor_char_prev ==# '0')
         \ || &nrformats =~# '\<hex\>' && (cursor_char =~# '[xX]' && cursor_char_next =~# '\x' && cursor_char_prev ==# '0')
-    let cmd = a:key
+    let cmd = a:key . ":\<c-u>let &l:iskeyword=b:CtrlXA_waskeyword | unlet b:CtrlXA_waskeyword\<cr>"
     return cmd . repeat_cmd
   else
     let line_length = len(getline('.'))


### PR DESCRIPTION
The previous commit

60722f050c39141e4ad7470e48a57a7fcfe99336 "reset &iskeyword in time"

did not reset &iskeyword when the toggle was a simple number. The
current commit fixes that.