### PR TITLE
Fix "unlet" raising an error on filetype change

### DIFF
--- a/ftplugin/c.vim
+++ b/ftplugin/c.vim
@@ -8,5 +8,5 @@ let b:CtrlXA_Toggles = [
       \ ['struct', 'union'],
       \ ['typedef', 'enum'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/cpp.vim
+++ b/ftplugin/cpp.vim
@@ -7,5 +7,5 @@ let b:CtrlXA_Toggles = [
       \ ['try', 'catch', 'throw'],
       \ ['class', 'struct', 'template'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/cs.vim
+++ b/ftplugin/cs.vim
@@ -9,5 +9,5 @@ let b:CtrlXA_Toggles = [
       \ ['class', 'interface'],
       \ ['this', 'base'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/gitrebase.vim
+++ b/ftplugin/gitrebase.vim
@@ -1,5 +1,5 @@
 let b:CtrlXA_Toggles = [ ['pick', 'fixup', 'squash', 'break', 'reword', 'edit', 'drop'] ]
       \ + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
 
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -8,5 +8,5 @@ let b:CtrlXA_Toggles = [
                   \ ['public', 'private'],
                   \ ['struct', 'interface'],
                   \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/haskell.vim
+++ b/ftplugin/haskell.vim
@@ -7,5 +7,5 @@ let b:CtrlXA_Toggles = [
       \ ['data', 'type'],
       \ ['class', 'instance'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/java.vim
+++ b/ftplugin/java.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
       \ ['this', 'super'],
       \ ['extends', 'implements'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -11,5 +11,5 @@ let b:CtrlXA_Toggles = [
       \ ['this', 'super'],
       \ ['extends', 'implements'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/kotlin.vim
+++ b/ftplugin/kotlin.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
       \ ['this', 'super'],
       \ ['extends', 'implements'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -5,5 +5,5 @@ let b:CtrlXA_Toggles = [
                   \ ['if', 'else', 'elseif', 'then', 'end'],
                   \ ['pcall', 'xpcall'],
                   \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -9,5 +9,5 @@ let b:CtrlXA_Toggles = [
                   \ ['shift', 'pop'],
                   \ ['bless', 'overload'],
                   \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
                   \ ['this', 'parent'],
                   \ ['extends', 'implements'],
                   \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -5,5 +5,5 @@ let b:CtrlXA_Toggles = [
       \ ['if', 'else', 'elif'],
       \ ['try', 'except', 'finally', 'raise'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -1,6 +1,6 @@
 let b:CtrlXA_Toggles = [
                   \ ['void', 'nil', 'float', 'String', 'boolean', 'char', 'byte', 'short', 'long', 'double'],
-                  \ ['for', 'while', 'until'], 
+                  \ ['for', 'while', 'until'],
                   \ ['break', 'next'],
                   \ ['if', 'else', 'case'],
                   \ ['begin', 'rescue', 'ensure', 'raise'],
@@ -9,5 +9,5 @@ let b:CtrlXA_Toggles = [
                   \ ['self', 'super'],
                   \ ['<', 'include'],
                   \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
       \ ['self', 'super'],
       \ ['impl', 'trait'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
       \ ['this', 'super'],
       \ ['extends', 'with'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/sh.vim
+++ b/ftplugin/sh.vim
@@ -10,6 +10,6 @@ let b:CtrlXA_Toggles = [
       \ ['eval', 'source', 'exec'],
       \ ['return', 'exit'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'
 

--- a/ftplugin/swift.vim
+++ b/ftplugin/swift.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
       \ ['self', 'super'],
       \ ['inherit', 'conforms'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -55,6 +55,6 @@ let b:CtrlXA_Toggles = [
                   \ ['english', 'ngerman', 'brazilian', 'french', 'italian'],
                   \ ['final', 'draft'],
                   \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+                  \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'
 

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -10,5 +10,5 @@ let b:CtrlXA_Toggles = [
       \ ['this', 'super'],
       \ ['extends', 'implements'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'

--- a/ftplugin/vim.vim
+++ b/ftplugin/vim.vim
@@ -8,5 +8,5 @@ let b:CtrlXA_Toggles = [
       \ ['if', 'else', 'elseif', 'endif'],
       \ ['let', 'unlet'],
       \ ] + get(b:, 'CtrlXA_Toggles', g:CtrlXA_Toggles)
-let b:undo_ftplugin = 
-      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet b:CtrlXA_Toggles' : 'unlet b:CtrlXA_Toggles'
+let b:undo_ftplugin =
+      \ exists('b:undo_ftplugin') ? b:undo_ftplugin . '| unlet! b:CtrlXA_Toggles' : 'unlet! b:CtrlXA_Toggles'


### PR DESCRIPTION
Hi! thanks for this plugin.

Noticed an error message that seems to be stemming from trying to unlet something that might not exist.

Thinking about it, you'd think these variables _should_ exist, but something is causing them to not between opening the buffer and switching filetypes.

- 🌎 undo_ftplugin undoes the effect of the previously set filetype. For CtrlXA, this unlets any buffer-specific cycles.
- ⛔ Sometimes variables are unset before switching, so there's not always a b:CtrlXA_Toggles set. Unletting this variable when non-existent causes an error
- ✅ This commit tells the unlets to fail silently if the variable is not set using `unlet!`