### PR TITLE
Fix autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you want to add a cycle, say the pair `['sweet', 'bitter']`, to the default l
     ```vim
     augroup VimAfter
         autocmd!
-        autocmd VimEnter let g:CtrlXA_Toggles = [
+        autocmd VimEnter * let g:CtrlXA_Toggles = [
         \ ['sweet', 'bitter'],
         \ ] + g:CtrlXA_Toggles
     augroup END


### PR DESCRIPTION
I wanted to add a `horizontal/vertical` cycle (not sure if this should be included in the defaults?). I copied the example, but it didn't work. After consulting `:help VimEnter`, it looks like the `autocmd` is missing an asterisk.